### PR TITLE
new redisInfo for multiple colons in info string

### DIFF
--- a/R/controlCMD.R
+++ b/R/controlCMD.R
@@ -86,23 +86,19 @@ function()
   remove(list='con',envir=.redisEnv$current)
 }
 
+
 `redisInfo` <-
-function()
-{
+function(){
   x <- .redisCmd(.raw('INFO'))
-  z <- strsplit(x,'\r\n')[[1]]
-  rj <- c(grep("^$",z), grep("^#",z))
-  if(length(rj)>0) z <- z[-rj]
-  z <- gsub(":$",": ",z,perl=TRUE)
-  z <- z[grep(":",z)]
-  if(length(z)<1) return(NULL)
-  w <- unlist(lapply(z,strsplit,':'))
-  n <- length(w)
-  e <- seq(from=2,to=n,by=2)
-  o <- seq(from=1,to=n,by=2)
-  z <- as.list(w[e])
-  names(z) <- w[o]
-  z
+  str <- strsplit(x,'\r\n')[[1]]
+  
+  splitvec <- regexec('^(.*?):([^#]*)(#.*)?',str)
+  matches <- regmatches(str,splitvec)
+  matches <- Filter(function(x)(length(x) > 0),matches)
+  keys <- sapply(matches,function(x)x[2])
+  vals <- lapply(matches,function(x)x[3])
+  names(vals) <- keys
+  return(vals)
 }
 
 `redisSlaveOf` <-


### PR DESCRIPTION
Second try - sorry after I fixed this, I found an unrelated bug, and closed it.  But I'm pretty sure this patch is right.

This is a change for redisInfo to work on windows; on windows it's possible (likely) that the configuration file part of the info looks like this:

config_file:C:\Redis/redis.windows.conf\r\n

when this happens, strsplit splits this into 3 and ultimately leads to an error like:

Error in names(z) <- w[o] :
'names' attribute [70] must be the same length as the vector [69]
